### PR TITLE
Make translations work after installation

### DIFF
--- a/obkey
+++ b/obkey
@@ -27,6 +27,8 @@
 #-----------------------------------------------------------------------
 
 import sys, os
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from gi.repository import GObject
 #~ import obkey_classes

--- a/obkey_classes.py
+++ b/obkey_classes.py
@@ -46,8 +46,8 @@ from xml.sax.saxutils import escape
 
 config_prefix = '/usr'
 config_icons = os.path.join(config_prefix, 'share/obkey/icons')
-#~ config_locale_dir = os.path.join(config_prefix, 'share/locale')
-config_locale_dir = os.path.join('./locale')
+config_locale_dir = os.path.join(config_prefix, 'share/locale')
+#config_locale_dir = os.path.join('./locale')
 
 gettext.install('obkey', config_locale_dir) # init gettext
 


### PR DESCRIPTION
The translations aren't picked up after installing obkey with "setup.py". It's looking for the translations in "./locale" instead of the global "/usr/share/locale".

Nsf's upstream obkey had "/usr/share/locale", but it got changed recently by luffah's fork  in [this commit](https://github.com/luffah/obkey/commit/d1aebbd86ced158edbb35af5a04fca6089dec3de) (he uses obkey without installing it system wide with "setup.py"). I assume that most people install obkey system wide and therefore the old behaviour makes more sense.

I also added the lines required to fix the small GTK related warning about specifying the GTK version.