### PR TITLE
Check that obstr is not None before splitting

### DIFF
--- a/obkey_classes.py
+++ b/obkey_classes.py
@@ -95,7 +95,8 @@ replace_table_gtk2openbox = {
 }
 
 def key_openbox2gtk(obstr):
-	toks = obstr.split("-")
+	if obstr is not None:
+		toks = obstr.split("-")
 	try:
 		toksgdk = [replace_table_openbox2gtk[mod.lower()] for mod in toks[:-1]]
 	except:


### PR DESCRIPTION
I believe this may be a recent update that has caused this issue, however it was a simple fix

This was the output I got prior

Traceback (most recent call last):
  File "/usr/bin/obkey", line 56, in <module>
    ktbl = obkey_classes.KeyTable(al, ob)
  File "/usr/lib/python2.7/site-packages/obkey_classes.py", line 196, in __init__
    self.apply_cqk_initial_value()
  File "/usr/lib/python2.7/site-packages/obkey_classes.py", line 411, in apply_cqk_initial_value
    cqk_accel_key, cqk_accel_mods = key_openbox2gtk(self.ob.keyboard.chainQuitKey)
  File "/usr/lib/python2.7/site-packages/obkey_classes.py", line 98, in key_openbox2gtk
    toks = obstr.split("-")
AttributeError: 'NoneType' object has no attribute 'split'
